### PR TITLE
v1.7.0: fix stale meta tags on unmount and undefined transitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ pnpm vitest run -t "test name pattern"
 
 The component returns `null` (no DOM output). The `updateMetaTag()` helper removes any existing matching `<meta>` element before inserting the new one, preventing duplicates.
 
+The `useLayoutEffect` tracks the selectors it inserts in a local `insertedSelectors` array and returns a cleanup function that removes them. This runs when deps change (handling prop → `undefined` transitions) and on unmount (preventing stale metadata across SPA page transitions). `document.title` is intentionally not restored on cleanup.
+
 Twitter Card tags are automatically derived from OG props — there are no separate Twitter-specific props. The exact mapping is:
 
 | OG prop | Also writes |
@@ -43,8 +45,13 @@ Twitter Card tags are automatically derived from OG props — there are no separ
 When adding a new meta tag prop, update all four of these locations:
 
 1. `src/types.ts` — add the prop to `ReactHeadSafeProps`
-2. `src/ReactHeadSafe.tsx` — destructure the prop, add `updateMetaTag()` call(s) inside `useLayoutEffect`, and add it to the dependency array
-3. `src/test/ReactHeadSafe.test.tsx` — add tests (creation, update on re-render, duplicate prevention)
+2. `src/ReactHeadSafe.tsx` — destructure the prop, add `updateMetaTag()` call(s) inside `useLayoutEffect`, **push the corresponding selector(s) to `insertedSelectors` so cleanup removes them**, and add the prop to the dependency array
+3. `src/test/ReactHeadSafe.test.tsx` — add tests (creation, update on re-render, duplicate prevention, **removal on unmount**, **removal when prop transitions to `undefined`**)
+4. `README.md` and `README.ko.md` — add the prop to the API Reference table
+
+### Code style
+
+Write all code comments in English — this overrides the global "Korean comments" rule. The library is published to npm for an international audience, so in-source comments must be English. User-facing documentation in README may still include a Korean translation (`README.ko.md`).
 
 ### Build output
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -137,6 +137,37 @@ Open Graph 태그를 설정하면 해당하는 Twitter Card 태그가 자동으�
 | `ogDescription` | `twitter:description` |
 | `ogImage`       | `twitter:image` + `twitter:card` (summary_large_image) |
 
+## 동작 방식
+
+### 언마운트 시 자동 정리
+
+`<ReactHeadSafe>` 인스턴스가 언마운트될 때 (예: SPA 페이지 전환 시), 해당 인스턴스가 삽입한 모든 meta/link 태그가 `<head>`에서 자동으로 제거됩니다. 페이지 간 stale 메타데이터 유출을 방지합니다.
+
+```tsx
+// v1.7.0 이전: /home에서 설정한 og:image가 /about에도 남아있었음
+// v1.7.0 이후: HomePage 언마운트 시 cleanup이 og:image를 자동 제거
+<Route path="/home" element={<HomePage />} />    {/* ogImage 사용 */}
+<Route path="/about" element={<AboutPage />} />  {/* ogImage 없음 */}
+```
+
+> **참고:** `document.title`은 언마운트 시 **복원되지 않습니다**. 다음 페이지의 `<ReactHeadSafe>`가 즉시 덮어쓰는 것이 일반적이기 때문에, 복원 시 순간적인 깜빡임이 발생할 수 있습니다. 후속 인스턴스가 `title`을 설정하지 않으면 이전 값이 남습니다.
+
+### `undefined` 전달로 태그 제거하기
+
+prop이 값에서 `undefined`로 변경되면 해당 태그가 제거됩니다. 컴포넌트를 언마운트하지 않고도 조건부로 태그를 빼고 싶을 때 사용하세요:
+
+```tsx
+<ReactHeadSafe
+  title="My Page"
+  ogImage={isSharable ? shareImage : undefined}
+/>
+```
+
+### 추적하지 않는 항목
+
+- **React 마운트 전에 `index.html`에 있던 태그** — `<ReactHeadSafe>`는 마운트 시 이들을 덮어쓰지만, 언마운트 시 **복원하지는 않습니다**. `index.html`은 "기본값" 계층으로, `<ReactHeadSafe>`는 "덮어쓰기" 계층으로 이해해주세요.
+- **동시에 여러 개의 `<ReactHeadSafe>` 인스턴스** — 두 인스턴스가 겹치는 prop을 동시에 설정하는 경우 동작을 보장하지 않습니다. 페이지당 하나의 인스턴스만 사용하세요.
+
 ## 로컬 개발
 
 예제 애플리케이션으로 로컬 변경사항을 테스트하려면:

--- a/README.md
+++ b/README.md
@@ -137,6 +137,37 @@ When you set Open Graph tags, the corresponding Twitter Card tags are automatica
 | `ogDescription` | `twitter:description` |
 | `ogImage`       | `twitter:image` + `twitter:card` (summary_large_image) |
 
+## Behavior
+
+### Automatic cleanup on unmount
+
+When a `<ReactHeadSafe>` instance unmounts (e.g., during SPA page transitions), all meta and link tags it inserted are automatically removed from `<head>`. This prevents stale metadata from leaking between pages.
+
+```tsx
+// Before v1.7.0: og:image set on /home would persist on /about
+// v1.7.0+:       cleanup removes og:image automatically when HomePage unmounts
+<Route path="/home" element={<HomePage />} />    {/* uses ogImage */}
+<Route path="/about" element={<AboutPage />} />  {/* no ogImage  */}
+```
+
+> **Note:** `document.title` is **not** restored on unmount. Since the next page's `<ReactHeadSafe>` typically overrides it immediately, restoring would cause a visible flash. If no subsequent instance sets `title`, the previous value remains.
+
+### Removing a tag by passing `undefined`
+
+If a prop transitions from a value to `undefined` on re-render, the corresponding tag is removed. This lets you conditionally drop a tag without unmounting the component:
+
+```tsx
+<ReactHeadSafe
+  title="My Page"
+  ogImage={isSharable ? shareImage : undefined}
+/>
+```
+
+### What is NOT tracked
+
+- **Tags present in `index.html` before React mounts** — `<ReactHeadSafe>` overwrites them on mount but does **not** restore them on unmount. Treat `index.html` as the "default" layer and `<ReactHeadSafe>` as the "override" layer.
+- **Multiple simultaneous instances** — behavior is not guaranteed when two `<ReactHeadSafe>` instances target overlapping props at the same time. Use a single instance per page.
+
 ## Local Development
 
 To test your local changes with the example application:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-head-safe",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "A lightweight React head manager for CSR apps. Safely manage document title, meta tags, Open Graph, and SEO metadata without duplicates. TypeScript support included.",
   "author": "umsungjun",
   "license": "MIT",

--- a/src/ReactHeadSafe.tsx
+++ b/src/ReactHeadSafe.tsx
@@ -31,7 +31,14 @@ export const ReactHeadSafe: FC<ReactHeadSafeProps> = ({
   canonicalUrl,
 }) => {
   useLayoutEffect(() => {
+    // Track selectors for meta/link tags inserted in this effect run.
+    // Cleanup only removes tags we inserted, preventing stale tags on
+    // unmount or when a prop transitions to undefined.
+    const insertedSelectors: string[] = [];
+
     // Update title
+    // NOTE: document.title is intentionally not restored on cleanup —
+    // the next page's ReactHeadSafe typically overwrites it immediately.
     if (title !== undefined) {
       document.title = title;
     }
@@ -39,42 +46,70 @@ export const ReactHeadSafe: FC<ReactHeadSafeProps> = ({
     // Update description meta tag
     if (description !== undefined) {
       updateMetaTag('name', 'description', description);
+      insertedSelectors.push('meta[name="description"]');
     }
 
     // Update keywords meta tag
     if (keywords !== undefined) {
       updateMetaTag('name', 'keywords', keywords);
+      insertedSelectors.push('meta[name="keywords"]');
     }
 
     // Update Open Graph tags and Twitter tags
     if (ogTitle !== undefined) {
       updateMetaTag('property', 'og:title', ogTitle);
       updateMetaTag('name', 'twitter:title', ogTitle);
+      insertedSelectors.push(
+        'meta[property="og:title"]',
+        'meta[name="twitter:title"]'
+      );
     }
 
     if (ogDescription !== undefined) {
       updateMetaTag('property', 'og:description', ogDescription);
       updateMetaTag('name', 'twitter:description', ogDescription);
+      insertedSelectors.push(
+        'meta[property="og:description"]',
+        'meta[name="twitter:description"]'
+      );
     }
 
     if (ogImage !== undefined) {
       updateMetaTag('property', 'og:image', ogImage);
       updateMetaTag('name', 'twitter:image', ogImage);
       updateMetaTag('name', 'twitter:card', 'summary_large_image');
+      insertedSelectors.push(
+        'meta[property="og:image"]',
+        'meta[name="twitter:image"]',
+        'meta[name="twitter:card"]'
+      );
     }
 
     if (ogUrl !== undefined) {
       updateMetaTag('property', 'og:url', ogUrl);
+      insertedSelectors.push('meta[property="og:url"]');
     }
 
     if (ogType !== undefined) {
       updateMetaTag('property', 'og:type', ogType);
+      insertedSelectors.push('meta[property="og:type"]');
     }
 
     // Update canonical URL
     if (canonicalUrl !== undefined) {
       updateLinkTag('canonical', canonicalUrl);
+      insertedSelectors.push('link[rel="canonical"]');
     }
+
+    // Cleanup: remove every tag this effect inserted.
+    // - On deps change: runs before the next effect, clearing stale tags
+    //   (handles prop → undefined transitions).
+    // - On unmount: final run, preventing stale metadata across pages.
+    return () => {
+      insertedSelectors.forEach((selector) => {
+        document.querySelector(selector)?.remove();
+      });
+    };
   }, [
     title,
     description,

--- a/src/test/ReactHeadSafe.test.tsx
+++ b/src/test/ReactHeadSafe.test.tsx
@@ -451,4 +451,185 @@ describe('ReactHeadSafe', () => {
       }).not.toThrow();
     });
   });
+
+  describe('cleanup on unmount', () => {
+    it('should remove all inserted meta and link tags on unmount', () => {
+      const { unmount } = render(
+        <ReactHeadSafe
+          description="Test"
+          keywords="test,cleanup"
+          ogTitle="OG Title"
+          ogDescription="OG Description"
+          ogImage="https://example.com/img.jpg"
+          ogUrl="https://example.com"
+          ogType="website"
+          canonicalUrl="https://example.com"
+        />
+      );
+
+      // Sanity check: a representative tag exists before unmount
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('meta[property="og:title"]')
+      ).toBeInTheDocument();
+
+      unmount();
+
+      // After unmount: every inserted meta/link tag must be gone
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="keywords"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[property="og:title"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="twitter:title"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[property="og:description"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="twitter:description"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[property="og:image"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="twitter:image"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="twitter:card"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[property="og:url"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[property="og:type"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('link[rel="canonical"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should NOT reset document.title on unmount', () => {
+      const { unmount } = render(<ReactHeadSafe title="Page Title" />);
+      expect(document.title).toBe('Page Title');
+
+      unmount();
+
+      // title is intentionally NOT restored — next page's ReactHeadSafe overwrites it
+      expect(document.title).toBe('Page Title');
+    });
+  });
+
+  describe('prop transitioning to undefined', () => {
+    it('should remove description meta tag when prop becomes undefined', () => {
+      const { rerender } = render(<ReactHeadSafe description="Initial" />);
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).toBeInTheDocument();
+
+      rerender(<ReactHeadSafe />);
+
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should remove og and twitter tags together when ogTitle becomes undefined', () => {
+      const { rerender } = render(<ReactHeadSafe ogTitle="Title" />);
+      expect(
+        document.querySelector('meta[property="og:title"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="twitter:title"]')
+      ).toBeInTheDocument();
+
+      rerender(<ReactHeadSafe />);
+
+      expect(
+        document.querySelector('meta[property="og:title"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="twitter:title"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should remove twitter:card when ogImage becomes undefined', () => {
+      const { rerender } = render(
+        <ReactHeadSafe ogImage="https://example.com/img.jpg" />
+      );
+      expect(
+        document.querySelector('meta[name="twitter:card"]')
+      ).toBeInTheDocument();
+
+      rerender(<ReactHeadSafe />);
+
+      expect(
+        document.querySelector('meta[property="og:image"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="twitter:image"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="twitter:card"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should remove canonical link when canonicalUrl becomes undefined', () => {
+      const { rerender } = render(
+        <ReactHeadSafe canonicalUrl="https://example.com" />
+      );
+      expect(
+        document.querySelector('link[rel="canonical"]')
+      ).toBeInTheDocument();
+
+      rerender(<ReactHeadSafe />);
+
+      expect(
+        document.querySelector('link[rel="canonical"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should remove only the unset prop and keep others', () => {
+      const { rerender } = render(
+        <ReactHeadSafe description="Desc" ogTitle="Title" />
+      );
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('meta[property="og:title"]')
+      ).toBeInTheDocument();
+
+      // Drop description; ogTitle should remain
+      rerender(<ReactHeadSafe ogTitle="Title" />);
+
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[property="og:title"]')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('multiple rerenders', () => {
+    it('should not accumulate duplicate tags across many rerenders', () => {
+      const { rerender } = render(<ReactHeadSafe description="v1" />);
+
+      for (let i = 2; i <= 10; i++) {
+        rerender(<ReactHeadSafe description={`v${i}`} />);
+      }
+
+      const tags = document.querySelectorAll('meta[name="description"]');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].getAttribute('content')).toBe('v10');
+    });
+  });
 });


### PR DESCRIPTION
Up to v1.6.1, `useLayoutEffect` had no cleanup, so inserted meta/link tags lingered in `<head>` after unmount and stayed in the DOM even when a prop transitioned from a value back to `undefined` — causing stale social previews (e.g., the previous page's `og:image`) to leak across SPA navigations.

This PR fixes both issues by tracking every inserted selector in a local `insertedSelectors` array inside the effect and removing them in the returned cleanup function, which React runs before each re-render and on unmount. `document.title` is intentionally not restored since the next page's `<ReactHeadSafe>` typically overrides it immediately.

Also bumps the version to 1.7.0, adds 7 new test cases (unmount cleanup, undefined transitions, no accumulation across rerenders), documents the new behavior in a "Behavior" section in both READMEs, and fixes the "four locations" mismatch in `CLAUDE.md` while adding an English-comments code style rule. No breaking changes to the public API.

Verified with `pnpm test` (43/43), `pnpm exec tsc --noEmit` (0 errors), and `pnpm build` (ESM 1.92 KB / CJS 1.67 KB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified automatic cleanup behavior when component unmounts
  * Documented behavior for undefined prop transitions and title handling
  * Added comprehensive guides in English and Korean

* **Tests**
  * Expanded test coverage for unmount scenarios and tag removal workflows

* **Chores**
  * Version bumped to 1.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->