### PR TITLE
Feat/v1.8.0 add og twitter props

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,14 +31,16 @@ The component returns `null` (no DOM output). The `updateMetaTag()` helper remov
 
 The `useLayoutEffect` tracks the selectors it inserts in a local `insertedSelectors` array and returns a cleanup function that removes them. This runs when deps change (handling prop → `undefined` transitions) and on unmount (preventing stale metadata across SPA page transitions). `document.title` is intentionally not restored on cleanup.
 
-Twitter Card tags are automatically derived from OG props — there are no separate Twitter-specific props. The exact mapping is:
+Most Twitter Card tags are automatically derived from OG props:
 
-| OG prop | Also writes |
-|---|---|
-| `ogTitle` | `twitter:title` |
-| `ogDescription` | `twitter:description` |
-| `ogImage` | `twitter:image` + `twitter:card` (hardcoded to `summary_large_image`) |
-| `ogUrl`, `ogType` | *(no Twitter equivalent)* |
+| OG prop           | Also writes                                                           |
+| ----------------- | --------------------------------------------------------------------- |
+| `ogTitle`         | `twitter:title`                                                       |
+| `ogDescription`   | `twitter:description`                                                 |
+| `ogImage`         | `twitter:image` + `twitter:card` (hardcoded to `summary_large_image`) |
+| `ogUrl`, `ogType` | _(no Twitter equivalent)_                                             |
+
+`twitterSite` and `twitterCreator` are standalone Twitter-only props with no Open Graph equivalent — they write directly to `twitter:site` and `twitter:creator`.
 
 ### Adding a new prop
 
@@ -56,6 +58,7 @@ Write all code comments in English — this overrides the global "Korean comment
 ### Build output
 
 Vite is configured in library mode and produces:
+
 - `dist/index.js` — CommonJS
 - `dist/index.mjs` — ESM
 - `dist/index.d.ts` — TypeScript declarations

--- a/README.ko.md
+++ b/README.ko.md
@@ -115,27 +115,33 @@ function MyPage() {
 
 ### ReactHeadSafeProps
 
-| Prop            | Type     | Description                                                                 |
-| --------------- | -------- | --------------------------------------------------------------------------- |
-| `title`         | `string` | `document.title`에 설정될 페이지 제목                                       |
-| `description`   | `string` | SEO를 위한 메타 설명 태그 콘텐츠                                            |
-| `keywords`      | `string` | SEO를 위한 메타 키워드 태그 콘텐츠                                          |
-| `ogTitle`       | `string` | 소셜 미디어 공유를 위한 Open Graph 제목 (og:title)                          |
-| `ogDescription` | `string` | 소셜 미디어 공유를 위한 Open Graph 설명 (og:description)                    |
-| `ogImage`       | `string` | 소셜 미디어 공유를 위한 Open Graph 이미지 URL (og:image)                    |
-| `ogUrl`         | `string` | 소셜 미디어 공유를 위한 Open Graph URL (og:url)                             |
-| `ogType`        | `string` | 소셜 미디어 공유를 위한 Open Graph 타입, 예: "website", "article" (og:type) |
-| `canonicalUrl`  | `string` | SEO를 위한 페이지의 대표 URL (`<link rel="canonical">`)                     |
+| Prop             | Type     | Description                                                                 |
+| ---------------- | -------- | --------------------------------------------------------------------------- |
+| `title`          | `string` | `document.title`에 설정될 페이지 제목                                       |
+| `description`    | `string` | SEO를 위한 메타 설명 태그 콘텐츠                                            |
+| `keywords`       | `string` | SEO를 위한 메타 키워드 태그 콘텐츠                                          |
+| `ogTitle`        | `string` | 소셜 미디어 공유를 위한 Open Graph 제목 (og:title)                          |
+| `ogDescription`  | `string` | 소셜 미디어 공유를 위한 Open Graph 설명 (og:description)                    |
+| `ogImage`        | `string` | 소셜 미디어 공유를 위한 Open Graph 이미지 URL (og:image)                    |
+| `ogUrl`          | `string` | 소셜 미디어 공유를 위한 Open Graph URL (og:url)                             |
+| `ogType`         | `string` | 소셜 미디어 공유를 위한 Open Graph 타입, 예: "website", "article" (og:type) |
+| `canonicalUrl`   | `string` | SEO를 위한 페이지의 대표 URL (`<link rel="canonical">`)                     |
+| `ogSiteName`     | `string` | 소셜 미디어 공유를 위한 사이트 이름 (og:site_name)                          |
+| `ogLocale`       | `string` | 콘텐츠의 언어/지역 코드 (og:locale), 예: `"ko_KR"`, `"en_US"`               |
+| `twitterSite`    | `string` | 웹사이트의 Twitter 계정 (twitter:site), 예: `"@mysite"`                     |
+| `twitterCreator` | `string` | 콘텐츠 작성자의 Twitter 계정 (twitter:creator), 예: `"@author"`             |
 
 ### Twitter Card 지원
 
 Open Graph 태그를 설정하면 해당하는 Twitter Card 태그가 자동으로 생성됩니다:
 
-| Open Graph Prop | 생성되는 Twitter 태그 |
-| --------------- | --------------------- |
-| `ogTitle`       | `twitter:title`       |
-| `ogDescription` | `twitter:description` |
+| Open Graph Prop | 생성되는 Twitter 태그                                  |
+| --------------- | ------------------------------------------------------ |
+| `ogTitle`       | `twitter:title`                                        |
+| `ogDescription` | `twitter:description`                                  |
 | `ogImage`       | `twitter:image` + `twitter:card` (summary_large_image) |
+
+또한 `twitterSite`와 `twitterCreator`는 Open Graph 대응 항목 없이 `twitter:site`와 `twitter:creator`에 직접 씁니다.
 
 ## 동작 방식
 
@@ -157,10 +163,7 @@ Open Graph 태그를 설정하면 해당하는 Twitter Card 태그가 자동으�
 prop이 값에서 `undefined`로 변경되면 해당 태그가 제거됩니다. 컴포넌트를 언마운트하지 않고도 조건부로 태그를 빼고 싶을 때 사용하세요:
 
 ```tsx
-<ReactHeadSafe
-  title="My Page"
-  ogImage={isSharable ? shareImage : undefined}
-/>
+<ReactHeadSafe title="My Page" ogImage={isSharable ? shareImage : undefined} />
 ```
 
 ### 추적하지 않는 항목

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ For optimal SEO, always set default meta tags directly in your `index.html`:
     <title>My App</title>
     <meta name="description" content="Default description for your app." />
     <meta property="og:title" content="My App" />
-    <meta property="og:description" content="Default description for your app." />
+    <meta
+      property="og:description"
+      content="Default description for your app."
+    />
     <meta property="og:image" content="https://example.com/default-image.jpg" />
     <meta property="og:url" content="https://example.com" />
     <meta property="og:type" content="website" />
@@ -115,27 +118,33 @@ That's it! The component will automatically:
 
 ### ReactHeadSafeProps
 
-| Prop            | Type     | Description                                                                                  |
-| --------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `title`         | `string` | The page title that will be set in the `document.title`                                      |
-| `description`   | `string` | The meta description tag content for SEO                                                     |
-| `keywords`      | `string` | The meta keywords tag content for SEO                                                        |
-| `ogTitle`       | `string` | The Open Graph title (og:title) for social media sharing                                     |
-| `ogDescription` | `string` | The Open Graph description (og:description) for social media sharing                         |
-| `ogImage`       | `string` | The Open Graph image URL (og:image) for social media sharing                                 |
-| `ogUrl`         | `string` | The canonical URL of your object that will be used as its permanent ID in the graph (og:url) |
-| `ogType`        | `string` | The type of your object, e.g., "website", "article" (og:type)                                |
-| `canonicalUrl`  | `string` | The canonical URL of the page for SEO (`<link rel="canonical">`)                             |
+| Prop             | Type     | Description                                                                                  |
+| ---------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `title`          | `string` | The page title that will be set in the `document.title`                                      |
+| `description`    | `string` | The meta description tag content for SEO                                                     |
+| `keywords`       | `string` | The meta keywords tag content for SEO                                                        |
+| `ogTitle`        | `string` | The Open Graph title (og:title) for social media sharing                                     |
+| `ogDescription`  | `string` | The Open Graph description (og:description) for social media sharing                         |
+| `ogImage`        | `string` | The Open Graph image URL (og:image) for social media sharing                                 |
+| `ogUrl`          | `string` | The canonical URL of your object that will be used as its permanent ID in the graph (og:url) |
+| `ogType`         | `string` | The type of your object, e.g., "website", "article" (og:type)                                |
+| `canonicalUrl`   | `string` | The canonical URL of the page for SEO (`<link rel="canonical">`)                             |
+| `ogSiteName`     | `string` | The site name for social media sharing (og:site_name)                                        |
+| `ogLocale`       | `string` | The locale of the content (og:locale), e.g. `"en_US"`, `"ko_KR"`                             |
+| `twitterSite`    | `string` | The Twitter @username of the website (twitter:site), e.g. `"@mysite"`                        |
+| `twitterCreator` | `string` | The Twitter @username of the content author (twitter:creator), e.g. `"@author"`              |
 
 ### Twitter Card Support
 
 When you set Open Graph tags, the corresponding Twitter Card tags are automatically generated:
 
-| Open Graph Prop | Twitter Tag Generated |
-| --------------- | --------------------- |
-| `ogTitle`       | `twitter:title`       |
-| `ogDescription` | `twitter:description` |
+| Open Graph Prop | Twitter Tag Generated                                  |
+| --------------- | ------------------------------------------------------ |
+| `ogTitle`       | `twitter:title`                                        |
+| `ogDescription` | `twitter:description`                                  |
 | `ogImage`       | `twitter:image` + `twitter:card` (summary_large_image) |
+
+In addition, `twitterSite` and `twitterCreator` write directly to `twitter:site` and `twitter:creator` with no Open Graph equivalent.
 
 ## Behavior
 
@@ -157,10 +166,7 @@ When a `<ReactHeadSafe>` instance unmounts (e.g., during SPA page transitions), 
 If a prop transitions from a value to `undefined` on re-render, the corresponding tag is removed. This lets you conditionally drop a tag without unmounting the component:
 
 ```tsx
-<ReactHeadSafe
-  title="My Page"
-  ogImage={isSharable ? shareImage : undefined}
-/>
+<ReactHeadSafe title="My Page" ogImage={isSharable ? shareImage : undefined} />
 ```
 
 ### What is NOT tracked

--- a/examples/basic/src/pages/About.tsx
+++ b/examples/basic/src/pages/About.tsx
@@ -12,7 +12,11 @@ export default function About() {
         ogImage={`${window.location.origin}/logo.png`}
         ogUrl={window.location.href}
         ogType="website"
+        ogSiteName="React Head Safe Demo"
+        ogLocale="en_US"
         canonicalUrl={window.location.href}
+        twitterSite="@reactheadsafe"
+        twitterCreator="@umsungjun"
       />
 
       <div className="page-container">

--- a/examples/basic/src/pages/Contact.tsx
+++ b/examples/basic/src/pages/Contact.tsx
@@ -12,7 +12,11 @@ export default function Contact() {
         ogImage={`${window.location.origin}/logo.png`}
         ogUrl={window.location.href}
         ogType="website"
+        ogSiteName="React Head Safe Demo"
+        ogLocale="en_US"
         canonicalUrl={window.location.href}
+        twitterSite="@reactheadsafe"
+        twitterCreator="@umsungjun"
       />
 
       <div className="page-container">

--- a/examples/basic/src/pages/Home.tsx
+++ b/examples/basic/src/pages/Home.tsx
@@ -12,7 +12,11 @@ export default function Home() {
         ogImage={`${window.location.origin}/logo.png`}
         ogUrl={window.location.href}
         ogType="website"
+        ogSiteName="React Head Safe Demo"
+        ogLocale="en_US"
         canonicalUrl={window.location.href}
+        twitterSite="@reactheadsafe"
+        twitterCreator="@umsungjun"
       />
 
       <div className="page-container">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-head-safe",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "A lightweight React head manager for CSR apps. Safely manage document title, meta tags, Open Graph, and SEO metadata without duplicates. TypeScript support included.",
   "author": "umsungjun",
   "license": "MIT",

--- a/src/ReactHeadSafe.tsx
+++ b/src/ReactHeadSafe.tsx
@@ -29,6 +29,10 @@ export const ReactHeadSafe: FC<ReactHeadSafeProps> = ({
   ogUrl,
   ogType,
   canonicalUrl,
+  ogSiteName,
+  ogLocale,
+  twitterSite,
+  twitterCreator,
 }) => {
   useLayoutEffect(() => {
     // Track selectors for meta/link tags inserted in this effect run.
@@ -101,6 +105,26 @@ export const ReactHeadSafe: FC<ReactHeadSafeProps> = ({
       insertedSelectors.push('link[rel="canonical"]');
     }
 
+    if (ogSiteName !== undefined) {
+      updateMetaTag('property', 'og:site_name', ogSiteName);
+      insertedSelectors.push('meta[property="og:site_name"]');
+    }
+
+    if (ogLocale !== undefined) {
+      updateMetaTag('property', 'og:locale', ogLocale);
+      insertedSelectors.push('meta[property="og:locale"]');
+    }
+
+    if (twitterSite !== undefined) {
+      updateMetaTag('name', 'twitter:site', twitterSite);
+      insertedSelectors.push('meta[name="twitter:site"]');
+    }
+
+    if (twitterCreator !== undefined) {
+      updateMetaTag('name', 'twitter:creator', twitterCreator);
+      insertedSelectors.push('meta[name="twitter:creator"]');
+    }
+
     // Cleanup: remove every tag this effect inserted.
     // - On deps change: runs before the next effect, clearing stale tags
     //   (handles prop → undefined transitions).
@@ -120,6 +144,10 @@ export const ReactHeadSafe: FC<ReactHeadSafeProps> = ({
     ogUrl,
     ogType,
     canonicalUrl,
+    ogSiteName,
+    ogLocale,
+    twitterSite,
+    twitterCreator,
   ]);
 
   return null;

--- a/src/test/ReactHeadSafe.test.tsx
+++ b/src/test/ReactHeadSafe.test.tsx
@@ -408,9 +408,7 @@ describe('ReactHeadSafe', () => {
           ?.getAttribute('content')
       ).toBe('website');
       expect(
-        document
-          .querySelector('link[rel="canonical"]')
-          ?.getAttribute('href')
+        document.querySelector('link[rel="canonical"]')?.getAttribute('href')
       ).toBe('https://example.com/page');
     });
 
@@ -449,6 +447,190 @@ describe('ReactHeadSafe', () => {
       expect(() => {
         render(<ReactHeadSafe title="Test" />);
       }).not.toThrow();
+    });
+  });
+
+  describe('og:site_name meta tag', () => {
+    it('should create og:site_name meta tag', () => {
+      render(<ReactHeadSafe ogSiteName="My Site" />);
+
+      const metaTag = document.querySelector('meta[property="og:site_name"]');
+      expect(metaTag).toBeInTheDocument();
+      expect(metaTag?.getAttribute('content')).toBe('My Site');
+    });
+
+    it('should update og:site_name meta tag when prop changes', () => {
+      const { rerender } = render(<ReactHeadSafe ogSiteName="Initial Site" />);
+      rerender(<ReactHeadSafe ogSiteName="Updated Site" />);
+
+      const metaTag = document.querySelector('meta[property="og:site_name"]');
+      expect(metaTag?.getAttribute('content')).toBe('Updated Site');
+    });
+
+    it('should prevent duplicate og:site_name meta tags', () => {
+      const { rerender } = render(<ReactHeadSafe ogSiteName="First" />);
+      rerender(<ReactHeadSafe ogSiteName="Second" />);
+
+      const metaTags = document.querySelectorAll(
+        'meta[property="og:site_name"]'
+      );
+      expect(metaTags).toHaveLength(1);
+      expect(metaTags[0].getAttribute('content')).toBe('Second');
+    });
+
+    it('should remove og:site_name meta tag on unmount', () => {
+      const { unmount } = render(<ReactHeadSafe ogSiteName="My Site" />);
+      unmount();
+
+      expect(
+        document.querySelector('meta[property="og:site_name"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should remove og:site_name meta tag when prop becomes undefined', () => {
+      const { rerender } = render(<ReactHeadSafe ogSiteName="My Site" />);
+      rerender(<ReactHeadSafe />);
+
+      expect(
+        document.querySelector('meta[property="og:site_name"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('og:locale meta tag', () => {
+    it('should create og:locale meta tag', () => {
+      render(<ReactHeadSafe ogLocale="ko_KR" />);
+
+      const metaTag = document.querySelector('meta[property="og:locale"]');
+      expect(metaTag).toBeInTheDocument();
+      expect(metaTag?.getAttribute('content')).toBe('ko_KR');
+    });
+
+    it('should update og:locale meta tag when prop changes', () => {
+      const { rerender } = render(<ReactHeadSafe ogLocale="ko_KR" />);
+      rerender(<ReactHeadSafe ogLocale="en_US" />);
+
+      const metaTag = document.querySelector('meta[property="og:locale"]');
+      expect(metaTag?.getAttribute('content')).toBe('en_US');
+    });
+
+    it('should prevent duplicate og:locale meta tags', () => {
+      const { rerender } = render(<ReactHeadSafe ogLocale="ko_KR" />);
+      rerender(<ReactHeadSafe ogLocale="en_US" />);
+
+      const metaTags = document.querySelectorAll('meta[property="og:locale"]');
+      expect(metaTags).toHaveLength(1);
+      expect(metaTags[0].getAttribute('content')).toBe('en_US');
+    });
+
+    it('should remove og:locale meta tag on unmount', () => {
+      const { unmount } = render(<ReactHeadSafe ogLocale="ko_KR" />);
+      unmount();
+
+      expect(
+        document.querySelector('meta[property="og:locale"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should remove og:locale meta tag when prop becomes undefined', () => {
+      const { rerender } = render(<ReactHeadSafe ogLocale="ko_KR" />);
+      rerender(<ReactHeadSafe />);
+
+      expect(
+        document.querySelector('meta[property="og:locale"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('twitter:site meta tag', () => {
+    it('should create twitter:site meta tag', () => {
+      render(<ReactHeadSafe twitterSite="@mysite" />);
+
+      const metaTag = document.querySelector('meta[name="twitter:site"]');
+      expect(metaTag).toBeInTheDocument();
+      expect(metaTag?.getAttribute('content')).toBe('@mysite');
+    });
+
+    it('should update twitter:site meta tag when prop changes', () => {
+      const { rerender } = render(<ReactHeadSafe twitterSite="@oldsite" />);
+      rerender(<ReactHeadSafe twitterSite="@newsite" />);
+
+      const metaTag = document.querySelector('meta[name="twitter:site"]');
+      expect(metaTag?.getAttribute('content')).toBe('@newsite');
+    });
+
+    it('should prevent duplicate twitter:site meta tags', () => {
+      const { rerender } = render(<ReactHeadSafe twitterSite="@first" />);
+      rerender(<ReactHeadSafe twitterSite="@second" />);
+
+      const metaTags = document.querySelectorAll('meta[name="twitter:site"]');
+      expect(metaTags).toHaveLength(1);
+      expect(metaTags[0].getAttribute('content')).toBe('@second');
+    });
+
+    it('should remove twitter:site meta tag on unmount', () => {
+      const { unmount } = render(<ReactHeadSafe twitterSite="@mysite" />);
+      unmount();
+
+      expect(
+        document.querySelector('meta[name="twitter:site"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should remove twitter:site meta tag when prop becomes undefined', () => {
+      const { rerender } = render(<ReactHeadSafe twitterSite="@mysite" />);
+      rerender(<ReactHeadSafe />);
+
+      expect(
+        document.querySelector('meta[name="twitter:site"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('twitter:creator meta tag', () => {
+    it('should create twitter:creator meta tag', () => {
+      render(<ReactHeadSafe twitterCreator="@author" />);
+
+      const metaTag = document.querySelector('meta[name="twitter:creator"]');
+      expect(metaTag).toBeInTheDocument();
+      expect(metaTag?.getAttribute('content')).toBe('@author');
+    });
+
+    it('should update twitter:creator meta tag when prop changes', () => {
+      const { rerender } = render(<ReactHeadSafe twitterCreator="@old" />);
+      rerender(<ReactHeadSafe twitterCreator="@new" />);
+
+      const metaTag = document.querySelector('meta[name="twitter:creator"]');
+      expect(metaTag?.getAttribute('content')).toBe('@new');
+    });
+
+    it('should prevent duplicate twitter:creator meta tags', () => {
+      const { rerender } = render(<ReactHeadSafe twitterCreator="@first" />);
+      rerender(<ReactHeadSafe twitterCreator="@second" />);
+
+      const metaTags = document.querySelectorAll(
+        'meta[name="twitter:creator"]'
+      );
+      expect(metaTags).toHaveLength(1);
+      expect(metaTags[0].getAttribute('content')).toBe('@second');
+    });
+
+    it('should remove twitter:creator meta tag on unmount', () => {
+      const { unmount } = render(<ReactHeadSafe twitterCreator="@author" />);
+      unmount();
+
+      expect(
+        document.querySelector('meta[name="twitter:creator"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should remove twitter:creator meta tag when prop becomes undefined', () => {
+      const { rerender } = render(<ReactHeadSafe twitterCreator="@author" />);
+      rerender(<ReactHeadSafe />);
+
+      expect(
+        document.querySelector('meta[name="twitter:creator"]')
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,4 +17,12 @@ export interface ReactHeadSafeProps {
   ogType?: string;
   /** The canonical URL of the page for SEO (link rel="canonical") */
   canonicalUrl?: string;
+  /** The site name for social media sharing (og:site_name) */
+  ogSiteName?: string;
+  /** The locale of the content (og:locale), e.g. "en_US", "ko_KR" */
+  ogLocale?: string;
+  /** The Twitter @username of the website (twitter:site), e.g. "@mysite" */
+  twitterSite?: string;
+  /** The Twitter @username of the content author (twitter:creator), e.g. "@author" */
+  twitterCreator?: string;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for four new metadata properties: Open Graph site name and locale, and Twitter site and creator attribution to the component.

* **Documentation**
  * Updated README and example pages to document the new metadata properties and their usage.

* **Tests**
  * Added comprehensive test coverage for new metadata properties, including update and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->