### PR TITLE
Fix/v1.11.0 head tag safety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,30 +24,32 @@ pnpm vitest run -t "test name pattern"
 ### Core flow
 
 1. `src/types.ts` — defines `ReactHeadSafeProps` (all optional strings)
-2. `src/ReactHeadSafe.tsx` — the only component; uses `useLayoutEffect` to synchronously mutate the DOM before paint
-3. `src/index.ts` — re-exports the component and its props type
+2. `src/ReactHeadSafe.tsx` — the only component; uses a `useIsomorphicLayoutEffect` (layout effect in the browser, `useEffect` fallback during SSR to silence React's warning) to synchronously mutate the DOM before paint
+3. `src/index.ts` — re-exports the component and its types
 
-The component returns `null` (no DOM output). The `updateMetaTag()` helper removes any existing matching `<meta>` element before inserting the new one, preventing duplicates.
+The component returns `null` (no DOM output). The `updateMetaTag()`/`updateLinkTag()` helpers remove **every** existing matching element (case-insensitive attribute match) before inserting the new one, preventing duplicates even when `index.html` ships more than one static tag.
 
-The `useLayoutEffect` tracks the selectors it inserts in a local `insertedSelectors` array and returns a cleanup function that removes them. This runs when deps change (handling prop → `undefined` transitions) and on unmount (preventing stale metadata across SPA page transitions). `document.title` is intentionally not restored on cleanup.
+The effect tracks the exact elements it creates in a local `insertedElements` array and returns a cleanup that calls `element.remove()` on each. Because cleanup removes element references (not selectors), unmounting one instance never deletes a tag that another instance has since replaced. Cleanup runs when deps change (handling prop → `undefined` transitions) and on unmount (preventing stale metadata across SPA page transitions). `document.title` is intentionally not restored on cleanup. Empty strings are treated the same as `undefined` — falsy values render nothing.
 
 Most Twitter Card tags are automatically derived from OG props:
 
-| OG prop           | Also writes                                                           |
-| ----------------- | --------------------------------------------------------------------- |
-| `ogTitle`         | `twitter:title`                                                       |
-| `ogDescription`   | `twitter:description`                                                 |
-| `ogImage`         | `twitter:image` + `twitter:card` (hardcoded to `summary_large_image`) |
-| `ogUrl`, `ogType` | _(no Twitter equivalent)_                                             |
+| OG prop           | Also writes               |
+| ----------------- | ------------------------- |
+| `ogTitle`         | `twitter:title`           |
+| `ogDescription`   | `twitter:description`     |
+| `ogImage`         | `twitter:image`           |
+| `ogUrl`, `ogType` | _(no Twitter equivalent)_ |
 
 `twitterSite` and `twitterCreator` are standalone Twitter-only props with no Open Graph equivalent — they write directly to `twitter:site` and `twitter:creator`.
+
+`twitter:card` is emitted whenever any Twitter tag is written (X/Twitter ignores cards without it), defaulting to `summary_large_image`; the `twitterCard` prop overrides the card type.
 
 ### Adding a new prop
 
 When adding a new meta tag prop, update all four of these locations:
 
 1. `src/types.ts` — add the prop to `ReactHeadSafeProps`
-2. `src/ReactHeadSafe.tsx` — destructure the prop, add `updateMetaTag()` call(s) inside `useLayoutEffect`, **push the corresponding selector(s) to `insertedSelectors` so cleanup removes them**, and add the prop to the dependency array
+2. `src/ReactHeadSafe.tsx` — destructure the prop, add `updateMetaTag()` call(s) inside the effect, **push the returned element(s) to `insertedElements` so cleanup removes them**, and add the prop to the dependency array
 3. `src/test/ReactHeadSafe.test.tsx` — add tests (creation, update on re-render, duplicate prevention, **removal on unmount**, **removal when prop transitions to `undefined`**)
 4. `README.md` and `README.ko.md` — add the prop to the API Reference table
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -124,22 +124,23 @@ function MyPage() {
 
 ### ReactHeadSafeProps
 
-| Prop             | Type     | Description                                                                                  |
-| ---------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `title`          | `string` | `document.title`에 설정될 페이지 제목                                                        |
-| `description`    | `string` | SEO를 위한 메타 설명 태그 콘텐츠                                                             |
-| `keywords`       | `string` | SEO를 위한 메타 키워드 태그 콘텐츠                                                           |
-| `ogTitle`        | `string` | 소셜 미디어 공유를 위한 Open Graph 제목 (og:title)                                           |
-| `ogDescription`  | `string` | 소셜 미디어 공유를 위한 Open Graph 설명 (og:description)                                     |
-| `ogImage`        | `string` | 소셜 미디어 공유를 위한 Open Graph 이미지 URL (og:image)                                     |
-| `ogUrl`          | `string` | 소셜 미디어 공유를 위한 Open Graph URL (og:url)                                              |
-| `ogType`         | `OgType` | Open Graph 타입 (og:type). 표준 12개 값 자동완성 + 임의 string 모두 허용                     |
-| `canonicalUrl`   | `string` | SEO를 위한 페이지의 대표 URL (`<link rel="canonical">`)                                      |
-| `ogSiteName`     | `string` | 소셜 미디어 공유를 위한 사이트 이름 (og:site_name)                                           |
-| `ogLocale`       | `string` | 콘텐츠의 언어/지역 코드 (og:locale), 예: `"ko_KR"`, `"en_US"`                                |
-| `twitterSite`    | `string` | 웹사이트의 Twitter 계정 (twitter:site), 예: `"@mysite"`                                      |
-| `twitterCreator` | `string` | 콘텐츠 작성자의 Twitter 계정 (twitter:creator), 예: `"@author"`                              |
-| `robots`         | `string` | 크롤러 색인을 제어하는 robots 메타 태그 콘텐츠, 예: `"noindex,follow"`, `"noindex,nofollow"` |
+| Prop             | Type          | Description                                                                                                                   |
+| ---------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `title`          | `string`      | `document.title`에 설정될 페이지 제목                                                                                         |
+| `description`    | `string`      | SEO를 위한 메타 설명 태그 콘텐츠                                                                                              |
+| `keywords`       | `string`      | SEO를 위한 메타 키워드 태그 콘텐츠                                                                                            |
+| `ogTitle`        | `string`      | 소셜 미디어 공유를 위한 Open Graph 제목 (og:title)                                                                            |
+| `ogDescription`  | `string`      | 소셜 미디어 공유를 위한 Open Graph 설명 (og:description)                                                                      |
+| `ogImage`        | `string`      | 소셜 미디어 공유를 위한 Open Graph 이미지 URL (og:image)                                                                      |
+| `ogUrl`          | `string`      | 소셜 미디어 공유를 위한 Open Graph URL (og:url)                                                                               |
+| `ogType`         | `OgType`      | Open Graph 타입 (og:type). 표준 12개 값 자동완성 + 임의 string 모두 허용                                                      |
+| `canonicalUrl`   | `string`      | SEO를 위한 페이지의 대표 URL (`<link rel="canonical">`)                                                                       |
+| `ogSiteName`     | `string`      | 소셜 미디어 공유를 위한 사이트 이름 (og:site_name)                                                                            |
+| `ogLocale`       | `string`      | 콘텐츠의 언어/지역 코드 (og:locale), 예: `"ko_KR"`, `"en_US"`                                                                 |
+| `twitterSite`    | `string`      | 웹사이트의 Twitter 계정 (twitter:site), 예: `"@mysite"`                                                                       |
+| `twitterCreator` | `string`      | 콘텐츠 작성자의 Twitter 계정 (twitter:creator), 예: `"@author"`                                                               |
+| `twitterCard`    | `TwitterCard` | Twitter 카드 타입 (twitter:card), 예: `"summary"`. 생략 시 Twitter 태그가 하나라도 있으면 `"summary_large_image"`가 기본 적용 |
+| `robots`         | `string`      | 크롤러 색인을 제어하는 robots 메타 태그 콘텐츠, 예: `"noindex,follow"`, `"noindex,nofollow"`                                  |
 
 > **주의:** JS로 주입된 `robots="noindex"`는 JavaScript를 렌더링하는 크롤러(예: Googlebot, 단 지연 있음)만 인식합니다. JS를 실행하지 않는 크롤러(상당수의 봇, 소셜 미디어 프리뷰 봇 등)는 이 태그를 무시하므로 페이지가 여전히 색인될 수 있습니다. 반드시 확실하게 색인에서 제외해야 하는 페이지라면, 서버 측 `X-Robots-Tag: noindex` 헤더를 사용하세요.
 
@@ -147,13 +148,23 @@ function MyPage() {
 
 Open Graph 태그를 설정하면 해당하는 Twitter Card 태그가 자동으로 생성됩니다:
 
-| Open Graph Prop | 생성되는 Twitter 태그                                  |
-| --------------- | ------------------------------------------------------ |
-| `ogTitle`       | `twitter:title`                                        |
-| `ogDescription` | `twitter:description`                                  |
-| `ogImage`       | `twitter:image` + `twitter:card` (summary_large_image) |
+| Open Graph Prop | 생성되는 Twitter 태그 |
+| --------------- | --------------------- |
+| `ogTitle`       | `twitter:title`       |
+| `ogDescription` | `twitter:description` |
+| `ogImage`       | `twitter:image`       |
 
 또한 `twitterSite`와 `twitterCreator`는 Open Graph 대응 항목 없이 `twitter:site`와 `twitter:creator`에 직접 씁니다.
+
+Twitter 태그가 하나라도 기록되면 `twitter:card` 태그도 자동으로 함께 생성됩니다 — X/Twitter는 `twitter:card`가 없는 카드를 무시하기 때문입니다. 기본값은 `summary_large_image`이며 `twitterCard` prop으로 변경할 수 있습니다 (`'summary'` · `'summary_large_image'` · `'app'` · `'player'` 또는 임의 문자열):
+
+```tsx
+<ReactHeadSafe
+  ogTitle="My Page"
+  ogImage="https://example.com/img.jpg"
+  twitterCard="summary"
+/>
+```
 
 ### `OgType` 표준값
 
@@ -192,10 +203,12 @@ prop이 값에서 `undefined`로 변경되면 해당 태그가 제거됩니다. 
 <ReactHeadSafe title="My Page" ogImage={isSharable ? shareImage : undefined} />
 ```
 
+빈 문자열(`""`)도 `undefined`와 완전히 동일하게 동작합니다: 태그를 렌더링하지 않고, 값에서 빈 문자열로 전환되면 기존 태그를 제거합니다. `title=""`이 브라우저 탭을 비우는 일도 없습니다.
+
 ### 추적하지 않는 항목
 
 - **React 마운트 전에 `index.html`에 있던 태그** — `<ReactHeadSafe>`는 마운트 시 이들을 덮어쓰지만, 언마운트 시 **복원하지는 않습니다**. `index.html`은 "기본값" 계층으로, `<ReactHeadSafe>`는 "덮어쓰기" 계층으로 이해해주세요.
-- **동시에 여러 개의 `<ReactHeadSafe>` 인스턴스** — 두 인스턴스가 겹치는 prop을 동시에 설정하는 경우 동작을 보장하지 않습니다. 페이지당 하나의 인스턴스만 사용하세요.
+- **동시에 여러 개의 `<ReactHeadSafe>` 인스턴스** — 두 인스턴스가 겹치는 prop을 설정하면 나중에 마운트된 인스턴스가 우선하며, 한 인스턴스의 언마운트가 다른 인스턴스 소유의 태그를 제거하지 않습니다. 다만 예측 가능한 메타데이터를 위해 페이지당 하나의 인스턴스 사용을 권장합니다.
 
 ## 로컬 개발
 

--- a/README.md
+++ b/README.md
@@ -127,22 +127,23 @@ That's it! The component will automatically:
 
 ### ReactHeadSafeProps
 
-| Prop             | Type     | Description                                                                                             |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| `title`          | `string` | The page title that will be set in the `document.title`                                                 |
-| `description`    | `string` | The meta description tag content for SEO                                                                |
-| `keywords`       | `string` | The meta keywords tag content for SEO                                                                   |
-| `ogTitle`        | `string` | The Open Graph title (og:title) for social media sharing                                                |
-| `ogDescription`  | `string` | The Open Graph description (og:description) for social media sharing                                    |
-| `ogImage`        | `string` | The Open Graph image URL (og:image) for social media sharing                                            |
-| `ogUrl`          | `string` | The canonical URL of your object that will be used as its permanent ID in the graph (og:url)            |
-| `ogType`         | `OgType` | The type of your object (og:type). Autocompletes 12 standard OG values; also accepts any string.        |
-| `canonicalUrl`   | `string` | The canonical URL of the page for SEO (`<link rel="canonical">`)                                        |
-| `ogSiteName`     | `string` | The site name for social media sharing (og:site_name)                                                   |
-| `ogLocale`       | `string` | The locale of the content (og:locale), e.g. `"en_US"`, `"ko_KR"`                                        |
-| `twitterSite`    | `string` | The Twitter @username of the website (twitter:site), e.g. `"@mysite"`                                   |
-| `twitterCreator` | `string` | The Twitter @username of the content author (twitter:creator), e.g. `"@author"`                         |
-| `robots`         | `string` | The robots meta tag content controlling crawler indexing, e.g. `"noindex,follow"`, `"noindex,nofollow"` |
+| Prop             | Type          | Description                                                                                                                                   |
+| ---------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`          | `string`      | The page title that will be set in the `document.title`                                                                                       |
+| `description`    | `string`      | The meta description tag content for SEO                                                                                                      |
+| `keywords`       | `string`      | The meta keywords tag content for SEO                                                                                                         |
+| `ogTitle`        | `string`      | The Open Graph title (og:title) for social media sharing                                                                                      |
+| `ogDescription`  | `string`      | The Open Graph description (og:description) for social media sharing                                                                          |
+| `ogImage`        | `string`      | The Open Graph image URL (og:image) for social media sharing                                                                                  |
+| `ogUrl`          | `string`      | The canonical URL of your object that will be used as its permanent ID in the graph (og:url)                                                  |
+| `ogType`         | `OgType`      | The type of your object (og:type). Autocompletes 12 standard OG values; also accepts any string.                                              |
+| `canonicalUrl`   | `string`      | The canonical URL of the page for SEO (`<link rel="canonical">`)                                                                              |
+| `ogSiteName`     | `string`      | The site name for social media sharing (og:site_name)                                                                                         |
+| `ogLocale`       | `string`      | The locale of the content (og:locale), e.g. `"en_US"`, `"ko_KR"`                                                                              |
+| `twitterSite`    | `string`      | The Twitter @username of the website (twitter:site), e.g. `"@mysite"`                                                                         |
+| `twitterCreator` | `string`      | The Twitter @username of the content author (twitter:creator), e.g. `"@author"`                                                               |
+| `twitterCard`    | `TwitterCard` | The Twitter card type (twitter:card), e.g. `"summary"`. When omitted, defaults to `"summary_large_image"` whenever any Twitter tag is written |
+| `robots`         | `string`      | The robots meta tag content controlling crawler indexing, e.g. `"noindex,follow"`, `"noindex,nofollow"`                                       |
 
 > **Warning:** A JS-injected `robots="noindex"` is only honored by crawlers that render JavaScript (e.g. Googlebot, with delay). Non-JS crawlers (many bots, social preview crawlers) ignore it, so the page may still be indexed. For pages that must be reliably excluded from indexing, use a server-side `X-Robots-Tag: noindex` header instead.
 
@@ -150,13 +151,23 @@ That's it! The component will automatically:
 
 When you set Open Graph tags, the corresponding Twitter Card tags are automatically generated:
 
-| Open Graph Prop | Twitter Tag Generated                                  |
-| --------------- | ------------------------------------------------------ |
-| `ogTitle`       | `twitter:title`                                        |
-| `ogDescription` | `twitter:description`                                  |
-| `ogImage`       | `twitter:image` + `twitter:card` (summary_large_image) |
+| Open Graph Prop | Twitter Tag Generated |
+| --------------- | --------------------- |
+| `ogTitle`       | `twitter:title`       |
+| `ogDescription` | `twitter:description` |
+| `ogImage`       | `twitter:image`       |
 
 In addition, `twitterSite` and `twitterCreator` write directly to `twitter:site` and `twitter:creator` with no Open Graph equivalent.
+
+Whenever any Twitter tag is written, a `twitter:card` tag is emitted automatically as well — X/Twitter ignores cards that lack it. It defaults to `summary_large_image` and can be overridden with the `twitterCard` prop (`'summary'` · `'summary_large_image'` · `'app'` · `'player'`, or any custom string):
+
+```tsx
+<ReactHeadSafe
+  ogTitle="My Page"
+  ogImage="https://example.com/img.jpg"
+  twitterCard="summary"
+/>
+```
 
 ### `OgType` standard values
 
@@ -195,10 +206,12 @@ If a prop transitions from a value to `undefined` on re-render, the correspondin
 <ReactHeadSafe title="My Page" ogImage={isSharable ? shareImage : undefined} />
 ```
 
+An empty string (`""`) behaves exactly like `undefined`: no tag is rendered, and an existing tag is removed on the transition. `title=""` never blanks the browser tab.
+
 ### What is NOT tracked
 
 - **Tags present in `index.html` before React mounts** — `<ReactHeadSafe>` overwrites them on mount but does **not** restore them on unmount. Treat `index.html` as the "default" layer and `<ReactHeadSafe>` as the "override" layer.
-- **Multiple simultaneous instances** — behavior is not guaranteed when two `<ReactHeadSafe>` instances target overlapping props at the same time. Use a single instance per page.
+- **Multiple simultaneous instances** — when two `<ReactHeadSafe>` instances target overlapping props, the last-mounted instance wins, and unmounting one instance never removes a tag currently owned by another. Still, prefer a single instance per page for predictable metadata.
 
 ## Local Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-head-safe",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "A lightweight React head manager for CSR apps. Safely manage document title, meta tags, Open Graph, and SEO metadata without duplicates. TypeScript support included.",
   "author": "umsungjun",
   "license": "MIT",

--- a/src/ReactHeadSafe.tsx
+++ b/src/ReactHeadSafe.tsx
@@ -1,5 +1,11 @@
-import { FC, useLayoutEffect } from 'react';
+import { FC, useEffect, useLayoutEffect } from 'react';
 import { type ReactHeadSafeProps } from './types';
+
+// Falls back to useEffect during SSR to avoid React's
+// "useLayoutEffect does nothing on the server" warning.
+// The library stays CSR-only: no tags are ever emitted on the server.
+const useIsomorphicLayoutEffect =
+  typeof document !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * @description
@@ -33,103 +39,109 @@ export const ReactHeadSafe: FC<ReactHeadSafeProps> = ({
   ogLocale,
   twitterSite,
   twitterCreator,
+  twitterCard,
   robots,
 }) => {
-  useLayoutEffect(() => {
-    // Track selectors for meta/link tags inserted in this effect run.
-    // Cleanup only removes tags we inserted, preventing stale tags on
-    // unmount or when a prop transitions to undefined.
-    const insertedSelectors: string[] = [];
+  useIsomorphicLayoutEffect(() => {
+    // Track the exact elements inserted in this effect run.
+    // Cleanup removes only these references, so it is a no-op for tags that
+    // another ReactHeadSafe instance has since replaced — preventing one
+    // instance's unmount from deleting a tag it no longer owns.
+    const insertedElements: HTMLElement[] = [];
+
+    // Empty strings are treated the same as undefined: no tag is rendered.
 
     // Update title
     // NOTE: document.title is intentionally not restored on cleanup —
     // the next page's ReactHeadSafe typically overwrites it immediately.
-    if (title !== undefined) {
+    if (title) {
       document.title = title;
     }
 
     // Update description meta tag
-    if (description !== undefined) {
-      updateMetaTag('name', 'description', description);
-      insertedSelectors.push('meta[name="description"]');
+    if (description) {
+      insertedElements.push(updateMetaTag('name', 'description', description));
     }
 
     // Update keywords meta tag
-    if (keywords !== undefined) {
-      updateMetaTag('name', 'keywords', keywords);
-      insertedSelectors.push('meta[name="keywords"]');
+    if (keywords) {
+      insertedElements.push(updateMetaTag('name', 'keywords', keywords));
     }
 
     // Update Open Graph tags and Twitter tags
-    if (ogTitle !== undefined) {
-      updateMetaTag('property', 'og:title', ogTitle);
-      updateMetaTag('name', 'twitter:title', ogTitle);
-      insertedSelectors.push(
-        'meta[property="og:title"]',
-        'meta[name="twitter:title"]'
+    if (ogTitle) {
+      insertedElements.push(
+        updateMetaTag('property', 'og:title', ogTitle),
+        updateMetaTag('name', 'twitter:title', ogTitle)
       );
     }
 
-    if (ogDescription !== undefined) {
-      updateMetaTag('property', 'og:description', ogDescription);
-      updateMetaTag('name', 'twitter:description', ogDescription);
-      insertedSelectors.push(
-        'meta[property="og:description"]',
-        'meta[name="twitter:description"]'
+    if (ogDescription) {
+      insertedElements.push(
+        updateMetaTag('property', 'og:description', ogDescription),
+        updateMetaTag('name', 'twitter:description', ogDescription)
       );
     }
 
-    if (ogImage !== undefined) {
-      updateMetaTag('property', 'og:image', ogImage);
-      updateMetaTag('name', 'twitter:image', ogImage);
-      updateMetaTag('name', 'twitter:card', 'summary_large_image');
-      insertedSelectors.push(
-        'meta[property="og:image"]',
-        'meta[name="twitter:image"]',
-        'meta[name="twitter:card"]'
+    if (ogImage) {
+      insertedElements.push(
+        updateMetaTag('property', 'og:image', ogImage),
+        updateMetaTag('name', 'twitter:image', ogImage)
       );
     }
 
-    if (ogUrl !== undefined) {
-      updateMetaTag('property', 'og:url', ogUrl);
-      insertedSelectors.push('meta[property="og:url"]');
+    if (ogUrl) {
+      insertedElements.push(updateMetaTag('property', 'og:url', ogUrl));
     }
 
-    if (ogType !== undefined) {
-      updateMetaTag('property', 'og:type', ogType);
-      insertedSelectors.push('meta[property="og:type"]');
+    if (ogType) {
+      insertedElements.push(updateMetaTag('property', 'og:type', ogType));
     }
 
     // Update canonical URL
-    if (canonicalUrl !== undefined) {
-      updateLinkTag('canonical', canonicalUrl);
-      insertedSelectors.push('link[rel="canonical"]');
+    if (canonicalUrl) {
+      insertedElements.push(updateLinkTag('canonical', canonicalUrl));
     }
 
-    if (ogSiteName !== undefined) {
-      updateMetaTag('property', 'og:site_name', ogSiteName);
-      insertedSelectors.push('meta[property="og:site_name"]');
+    if (ogSiteName) {
+      insertedElements.push(
+        updateMetaTag('property', 'og:site_name', ogSiteName)
+      );
     }
 
-    if (ogLocale !== undefined) {
-      updateMetaTag('property', 'og:locale', ogLocale);
-      insertedSelectors.push('meta[property="og:locale"]');
+    if (ogLocale) {
+      insertedElements.push(updateMetaTag('property', 'og:locale', ogLocale));
     }
 
-    if (twitterSite !== undefined) {
-      updateMetaTag('name', 'twitter:site', twitterSite);
-      insertedSelectors.push('meta[name="twitter:site"]');
+    if (twitterSite) {
+      insertedElements.push(updateMetaTag('name', 'twitter:site', twitterSite));
     }
 
-    if (twitterCreator !== undefined) {
-      updateMetaTag('name', 'twitter:creator', twitterCreator);
-      insertedSelectors.push('meta[name="twitter:creator"]');
+    if (twitterCreator) {
+      insertedElements.push(
+        updateMetaTag('name', 'twitter:creator', twitterCreator)
+      );
+    }
+
+    // Emit twitter:card whenever any Twitter tag is written — X/Twitter
+    // ignores cards that lack it. Defaults to "summary_large_image" and can
+    // be overridden via the twitterCard prop.
+    const hasTwitterTag = Boolean(
+      ogTitle || ogDescription || ogImage || twitterSite || twitterCreator
+    );
+    if (twitterCard || hasTwitterTag) {
+      insertedElements.push(
+        updateMetaTag(
+          'name',
+          'twitter:card',
+          twitterCard || 'summary_large_image'
+        )
+      );
     }
 
     // Update robots meta tag (controls crawler indexing, e.g. "noindex,follow")
-    if (robots !== undefined) {
-      updateMetaTag('name', 'robots', robots);
-      insertedSelectors.push('meta[name="robots"]');
+    if (robots) {
+      insertedElements.push(updateMetaTag('name', 'robots', robots));
     }
 
     // Cleanup: remove every tag this effect inserted.
@@ -137,8 +149,8 @@ export const ReactHeadSafe: FC<ReactHeadSafeProps> = ({
     //   (handles prop → undefined transitions).
     // - On unmount: final run, preventing stale metadata across pages.
     return () => {
-      insertedSelectors.forEach((selector) => {
-        document.querySelector(selector)?.remove();
+      insertedElements.forEach((element) => {
+        element.remove();
       });
     };
   }, [
@@ -155,6 +167,7 @@ export const ReactHeadSafe: FC<ReactHeadSafeProps> = ({
     ogLocale,
     twitterSite,
     twitterCreator,
+    twitterCard,
     robots,
   ]);
 
@@ -163,40 +176,38 @@ export const ReactHeadSafe: FC<ReactHeadSafeProps> = ({
 
 /**
  * Updates or creates a link tag in the document head.
- * Removes existing tag with the same rel to prevent duplicates.
+ * Removes every existing tag with the same rel (case-insensitive) to
+ * prevent duplicates, then returns the newly created element.
  */
-function updateLinkTag(rel: string, href: string): void {
-  const existingTag = document.querySelector(`link[rel="${rel}"]`);
-  if (existingTag) {
-    existingTag.remove();
-  }
+function updateLinkTag(rel: string, href: string): HTMLLinkElement {
+  document
+    .querySelectorAll(`link[rel="${rel}" i]`)
+    .forEach((tag) => tag.remove());
 
   const linkTag = document.createElement('link');
   linkTag.setAttribute('rel', rel);
   linkTag.setAttribute('href', href);
   document.head.appendChild(linkTag);
+  return linkTag;
 }
 
 /**
  * Updates or creates a meta tag in the document head.
- * Removes existing tag with the same identifier to prevent duplicates.
+ * Removes every existing tag with the same identifier (case-insensitive) to
+ * prevent duplicates, then returns the newly created element.
  */
 function updateMetaTag(
   attribute: 'name' | 'property',
   identifier: string,
   content: string
-): void {
-  // Remove existing meta tag with the same identifier
-  const existingTag = document.querySelector(
-    `meta[${attribute}="${identifier}"]`
-  );
-  if (existingTag) {
-    existingTag.remove();
-  }
+): HTMLMetaElement {
+  document
+    .querySelectorAll(`meta[${attribute}="${identifier}" i]`)
+    .forEach((tag) => tag.remove());
 
-  // Create and append new meta tag
   const metaTag = document.createElement('meta');
   metaTag.setAttribute(attribute, identifier);
   metaTag.setAttribute('content', content);
   document.head.appendChild(metaTag);
+  return metaTag;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { ReactHeadSafe } from './ReactHeadSafe';
-export type { ReactHeadSafeProps, OgType } from './types';
+export type { ReactHeadSafeProps, OgType, TwitterCard } from './types';

--- a/src/test/ReactHeadSafe.test.tsx
+++ b/src/test/ReactHeadSafe.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { ReactHeadSafe } from '../ReactHeadSafe';
+import { ReactHeadSafe as BarrelReactHeadSafe } from '../index';
 
 describe('ReactHeadSafe', () => {
   beforeEach(() => {
@@ -857,6 +858,223 @@ describe('ReactHeadSafe', () => {
       const tags = document.querySelectorAll('meta[name="description"]');
       expect(tags).toHaveLength(1);
       expect(tags[0].getAttribute('content')).toBe('v10');
+    });
+  });
+
+  describe('pre-existing tags in document head', () => {
+    it('should remove ALL pre-existing duplicate tags before inserting', () => {
+      // Simulates an index.html that ships more than one static tag
+      document.head.innerHTML =
+        '<meta name="description" content="static 1" />' +
+        '<meta name="description" content="static 2" />';
+
+      render(<ReactHeadSafe description="Fresh" />);
+
+      const tags = document.querySelectorAll('meta[name="description"]');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].getAttribute('content')).toBe('Fresh');
+    });
+
+    it('should replace pre-existing tags regardless of attribute value casing', () => {
+      document.head.innerHTML = '<meta name="ROBOTS" content="index,follow" />';
+
+      render(<ReactHeadSafe robots="noindex,nofollow" />);
+
+      const tags = document.querySelectorAll('meta[name="robots" i]');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].getAttribute('content')).toBe('noindex,nofollow');
+    });
+
+    it('should remove ALL pre-existing duplicate link tags before inserting', () => {
+      document.head.innerHTML =
+        '<link rel="canonical" href="https://old-1.example.com" />' +
+        '<link rel="canonical" href="https://old-2.example.com" />';
+
+      render(<ReactHeadSafe canonicalUrl="https://example.com" />);
+
+      const tags = document.querySelectorAll('link[rel="canonical"]');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].getAttribute('href')).toBe('https://example.com');
+    });
+  });
+
+  describe('multiple instances', () => {
+    it('should not let one instance unmount a tag another instance owns', () => {
+      const first = render(<ReactHeadSafe description="First" />);
+      render(<ReactHeadSafe description="Second" />);
+
+      // The second instance replaced the first instance's tag
+      let tags = document.querySelectorAll('meta[name="description"]');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].getAttribute('content')).toBe('Second');
+
+      // Unmounting the first instance must not delete the survivor's tag
+      first.unmount();
+
+      tags = document.querySelectorAll('meta[name="description"]');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].getAttribute('content')).toBe('Second');
+    });
+
+    it('should let the last-mounted sibling win for overlapping props', () => {
+      render(
+        <>
+          <ReactHeadSafe description="From layout" />
+          <ReactHeadSafe description="From page" />
+        </>
+      );
+
+      const tags = document.querySelectorAll('meta[name="description"]');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].getAttribute('content')).toBe('From page');
+    });
+  });
+
+  describe('React.StrictMode', () => {
+    it('should keep tags intact after StrictMode double-invokes effects', () => {
+      render(
+        <React.StrictMode>
+          <ReactHeadSafe
+            title="Strict Title"
+            description="Strict Desc"
+            ogTitle="Strict OG"
+          />
+        </React.StrictMode>
+      );
+
+      expect(document.title).toBe('Strict Title');
+
+      const descTags = document.querySelectorAll('meta[name="description"]');
+      expect(descTags).toHaveLength(1);
+      expect(descTags[0].getAttribute('content')).toBe('Strict Desc');
+
+      expect(
+        document.querySelectorAll('meta[property="og:title"]')
+      ).toHaveLength(1);
+    });
+
+    it('should clean up correctly on unmount under StrictMode', () => {
+      const { unmount } = render(
+        <React.StrictMode>
+          <ReactHeadSafe description="Strict Desc" />
+        </React.StrictMode>
+      );
+
+      unmount();
+
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty string props', () => {
+    it('should not render tags for empty string values', () => {
+      render(<ReactHeadSafe description="" robots="" ogTitle="" />);
+
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="robots"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[property="og:title"]')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('meta[name="twitter:card"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not blank document.title for an empty string', () => {
+      document.title = 'Existing Title';
+      render(<ReactHeadSafe title="" />);
+      expect(document.title).toBe('Existing Title');
+    });
+
+    it('should remove a tag when prop transitions to an empty string', () => {
+      const { rerender } = render(<ReactHeadSafe description="Initial" />);
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).toBeInTheDocument();
+
+      rerender(<ReactHeadSafe description="" />);
+
+      expect(
+        document.querySelector('meta[name="description"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('twitter:card emission', () => {
+    it('should emit default twitter:card when a twitter tag is written without ogImage', () => {
+      render(<ReactHeadSafe ogTitle="Title Only" />);
+
+      const card = document.querySelector('meta[name="twitter:card"]');
+      expect(card).toBeInTheDocument();
+      expect(card?.getAttribute('content')).toBe('summary_large_image');
+    });
+
+    it('should emit twitter:card for standalone twitter props', () => {
+      render(<ReactHeadSafe twitterSite="@mysite" />);
+
+      expect(
+        document
+          .querySelector('meta[name="twitter:card"]')
+          ?.getAttribute('content')
+      ).toBe('summary_large_image');
+    });
+
+    it('should override the card type via the twitterCard prop', () => {
+      render(
+        <ReactHeadSafe
+          ogImage="https://example.com/img.jpg"
+          twitterCard="summary"
+        />
+      );
+
+      const tags = document.querySelectorAll('meta[name="twitter:card"]');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].getAttribute('content')).toBe('summary');
+    });
+
+    it('should emit twitter:card when only twitterCard is provided', () => {
+      render(<ReactHeadSafe twitterCard="app" />);
+
+      expect(
+        document
+          .querySelector('meta[name="twitter:card"]')
+          ?.getAttribute('content')
+      ).toBe('app');
+    });
+
+    it('should not emit twitter:card when no twitter tag is written', () => {
+      render(
+        <ReactHeadSafe title="T" description="D" ogUrl="https://example.com" />
+      );
+
+      expect(
+        document.querySelector('meta[name="twitter:card"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should remove twitter:card when twitterCard becomes undefined', () => {
+      const { rerender } = render(<ReactHeadSafe twitterCard="summary" />);
+      expect(
+        document.querySelector('meta[name="twitter:card"]')
+      ).toBeInTheDocument();
+
+      rerender(<ReactHeadSafe />);
+
+      expect(
+        document.querySelector('meta[name="twitter:card"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('package entry point', () => {
+    it('should export the same component from the barrel (src/index.ts)', () => {
+      expect(BarrelReactHeadSafe).toBe(ReactHeadSafe);
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,21 @@ export type OgType =
   | 'music.radio_station'
   | (string & {});
 
+/**
+ * Standard Twitter Card types.
+ *
+ * Provides IDE autocompletion for the 4 well-known values while still
+ * accepting any string for forward compatibility (via `(string & {})`).
+ *
+ * @see https://developer.x.com/en/docs/x-for-websites/cards/overview/abouts-cards
+ */
+export type TwitterCard =
+  | 'summary'
+  | 'summary_large_image'
+  | 'app'
+  | 'player'
+  | (string & {});
+
 export interface ReactHeadSafeProps {
   /** The page title that will be set in the document.title */
   title?: string;
@@ -48,12 +63,8 @@ export interface ReactHeadSafeProps {
   twitterSite?: string;
   /** The Twitter @username of the content author (twitter:creator), e.g. "@author" */
   twitterCreator?: string;
-  /**
-   * The robots meta tag content controlling crawler indexing, e.g. "noindex,follow", "noindex,nofollow".
-   *
-   * Note: a JS-injected `noindex` is only honored by crawlers that render JavaScript
-   * (e.g. Googlebot, with delay). Non-JS crawlers ignore it. For pages that must be
-   * reliably excluded, use a server-side `X-Robots-Tag: noindex` header instead.
-   */
+  /** The Twitter card type (twitter:card). Defaults to "summary_large_image" whenever any Twitter tag is written */
+  twitterCard?: TwitterCard;
+  /** The robots meta tag content, e.g. "noindex,follow". Only honored by JS-rendering crawlers — for guaranteed exclusion use a server-side X-Robots-Tag header */
   robots?: string;
 }


### PR DESCRIPTION
## Summary

- Remove **all** pre-existing duplicate tags before inserting (`querySelectorAll` + case-insensitive attribute match) — previously only the first match was removed
- Track inserted **element references** for cleanup, so unmounting one `<ReactHeadSafe>` instance never deletes a tag owned by another instance
- Emit `twitter:card` whenever any Twitter tag is written (X/Twitter ignores cards without it), with a new `twitterCard` prop to override the default `summary_large_image`
- Treat empty strings (`""`) the same as `undefined` — no tag is rendered, and `title=""` no longer blanks the browser tab
- Silence the SSR `useLayoutEffect` warning via a `useIsomorphicLayoutEffect` fallback (the library remains CSR-only)
- Tests: 68 → 85 (pre-seeded duplicates, multiple instances, StrictMode, empty strings, twitter:card emission, barrel export)
- Docs: API tables and Behavior sections updated in both READMEs; version bumped to **1.11.0** (new prop → minor)

---

## 요약

- 삽입 전에 기존 중복 태그를 **전부** 제거 (`querySelectorAll` + 대소문자 무시 매칭) — 기존엔 첫 번째 하나만 제거됨
- cleanup이 셀렉터 재검색 대신 **자기가 만든 요소 참조**만 제거 → 한 인스턴스의 언마운트가 다른 인스턴스의 태그를 지우던 버그 해결
- Twitter 태그가 하나라도 기록되면 `twitter:card` 자동 생성 (X/트위터는 이 태그가 없는 카드를 무시), 새 `twitterCard` prop으로 기본값(`summary_large_image`) 변경 가능
- 빈 문자열(`""`)을 `undefined`와 동일 취급 — 태그를 만들지 않고, `title=""`이 브라우저 탭을 비우지 않음
- SSR 환경의 `useLayoutEffect` 경고를 `useIsomorphicLayoutEffect` 패턴으로 억제 (CSR 전용 설계는 유지)
- 테스트 68 → 85개 (사전 중복 시드, 다중 인스턴스, StrictMode, 빈 문자열, twitter:card, 배럴 export)
- README/README.ko 문서 갱신, 새 prop 추가로 **1.11.0** minor 범프


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `twitterCard` support with automatic `twitter:card` metadata and configurable card types.
  * Exported the `TwitterCard` type for improved TypeScript support.

* **Bug Fixes**
  * Improved metadata handling for duplicate tags, casing differences, and multiple component instances.
  * Empty-string values now remove tags without clearing the page title.
  * Improved SSR compatibility and Strict Mode behavior.

* **Documentation**
  * Updated API and behavior guidance, including Twitter Cards, cleanup behavior, and crawler considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->